### PR TITLE
The javadoc fn is in clojure.java.javadoc.

### DIFF
--- a/clojure-cheatsheet.el
+++ b/clojure-cheatsheet.el
@@ -358,7 +358,8 @@
 
     ("Documentation"
      ("REPL"
-      (clojure.repl doc find-doc apropos source pst javadoc )))
+      (clojure.repl doc find-doc apropos source pst)
+      (clojure.java.javadoc javadoc)))
 
     ("Transients"
      ("Create")


### PR DESCRIPTION
The clojure.org cheatsheet mislabels it as being in clojure.repl but it's actually in [clojure.java.javadoc](http://clojure.github.io/clojure/clojure.java.javadoc-api.html).
