### PR TITLE
Changes required by upstream renaming of nrepl.el to cider

### DIFF
--- a/clojure-cheatsheet.el
+++ b/clojure-cheatsheet.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/krisajenkins/clojure-cheatsheet
 ;; Created: 7th August 2013
 ;; Version: 0.1.1
-;; Package-Requires: ((helm "1.5.3") (nrepl "0.1.8"))
+;; Package-Requires: ((helm "1.5.3") (cider "0.1.8"))
 
 ;;; Commentary:
 ;;
@@ -15,7 +15,7 @@
 
 (require 'helm)
 (require 'helm-match-plugin)
-(require 'nrepl)
+(require 'nrepl-client)
 
 ;;; Code:
 


### PR DESCRIPTION
This is an informed guess at what needs to change, but could use some testing.

Can be safely merged if working, but please hold off on publishing to Marmalade because `cider` has not yet been added there.

BTW, you might consider moving this to the `clojure-emacs` github organisation. Let me know if interested.

-Steve
