### PR TITLE
Reference arbitrary precision arithmetic operators

### DIFF
--- a/clojure-cheatsheet.el
+++ b/clojure-cheatsheet.el
@@ -37,6 +37,8 @@
        (clojure.core rand rand-int))
       ("BigDecimal"
        (clojure.core with-precision))
+      ("Arbitrary Precision Arithmetic"
+       (clojure.core +\' -\' *\' /\'))
       ("Unchecked"
        (clojure.core *unchecked-math*
 		     unchecked-add


### PR DESCRIPTION
These aren't in the other cheatsheet, but seems useful to include in this one.
