### PR TITLE
Get documentation lookup working again.

### DIFF
--- a/clojure-cheatsheet.el
+++ b/clojure-cheatsheet.el
@@ -551,7 +551,7 @@ The head may be:
 (defun clojure-cheatsheet/lookup-doc
   (symbol)
   (if (nrepl-current-connection-buffer)
-      (cider-doc-handler symbol)
+      (cider-doc-lookup symbol)
     (error "nREPL not connected!")))
 
 (defun clojure-cheatsheet/lookup-src


### PR DESCRIPTION
Track latest master of Cider; the documentation lookup function has been renamed.
