### PR TITLE
Replacing nrepl-current-connection-buffer with cider-connected-p

### DIFF
--- a/clojure-cheatsheet.el
+++ b/clojure-cheatsheet.el
@@ -574,13 +574,13 @@ collections and transducers.")
 
 (defun clojure-cheatsheet/lookup-doc
     (symbol)
-  (if (nrepl-current-connection-buffer)
+  (if (cider-connected-p)
     (cider-doc-lookup symbol)
     (error "nREPL not connected!")))
 
 (defun clojure-cheatsheet/lookup-src
     (symbol)
-  (if (nrepl-current-connection-buffer)
+  (if (cider-connected-p)
     (cider-find-var nil symbol)
     (error "nREPL not connected!")))
 


### PR DESCRIPTION
The function "nrepl-current-connection-buffer" was removed from cider at some point, but we can get the same functionality with "cider-connected-p".

See issue #20.